### PR TITLE
527 Add TMC as `nestcolor` downstream dependency

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,4 +4,4 @@
 * `color_palette` function moved into `nestcolor` from `tern`.
   `DESCRIPTION` and `_pkgdown.yml` updated to include `color_palette`
 * Added lifecycle badges to the package
-* Added `tern` package as a downstream dependency to staged.dependencies
+* Added `tern`, `teal.modules.clinical` as downstream dependencies in staged.dependencies

--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -5,6 +5,9 @@ current_repo:
   host: https://github.com
 upstream_repos:
 downstream_repos:
+  insightsengineering/teal.modules.clinical:
+    repo: insightsengineering/teal.modules.clinical
+    host: https://github.com
   insightsengineering/tern:
     repo: insightsengineering/tern
     host: https://github.com


### PR DESCRIPTION
Required to merge PR insightsengineering/teal.modules.clinical#530