### PR TITLE
Add `rmarkdown` to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,8 @@ Imports:
     lifecycle
 Suggests:
     knitr,
-    testthat (>= 2.0)
+    testthat (>= 2.0),
+    rmarkdown
 VignetteBuilder:
     knitr
 RdMacros:


### PR DESCRIPTION
This fixes a build issue in R 4.0.4:

```
* creating vignettes ... ERROR
--- re-building ‘nestcolor.Rmd’ using rmarkdown
Error: processing vignette 'nestcolor.Rmd' failed with diagnostics:
The 'rmarkdown' package should be declared as a dependency of the 'nestcolor' package (e.g., in the  'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'rmarkdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
--- failed re-building ‘nestcolor.Rmd’
```
