### PR TITLE
remove teal.osprey from `staged.dependencies.yaml`

### DIFF
--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -23,9 +23,6 @@ downstream_repos:
   insightsengineering/teal.modules.clinical:
     repo: insightsengineering/teal.modules.clinical
     host: https://github.com
-  insightsengineering/teal.osprey:
-    repo: insightsengineering/teal.osprey
-    host: https://github.com
   insightsengineering/tern:
     repo: insightsengineering/tern
     host: https://github.com


### PR DESCRIPTION
Becuase nestcolor was removed here in teal.osprey https://github.com/insightsengineering/teal.osprey/pull/280/commits/8e7b32ac5f210a33f020a291efbce1226ac24993

